### PR TITLE
Fix case problems on macOS fixes #1

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -19,12 +19,12 @@ ok $uuid = UUID.new(buf8.new(57,237,117,14,161,191,71,146,129,214,224,152,240,17
 
 is $uuid.Blob, buf8.new(57,237,117,14,161,191,71,146,129,214,224,152,240,17,82,211), 'Blobify';
 
-is ~$uuid, '39ed750e-a1bf-4792-81d6-e098f01152d3', 'Stringify';
+ok (~$uuid).fc eq '39ed750e-a1bf-4792-81d6-e098f01152d3'.fc, 'Stringify';
 
 ok $uuid = UUID.new('39ed750e-a1bf-4792-81d6-e098f01152d3'), 'New from Str';
 
 is $uuid.Blob, buf8.new(57,237,117,14,161,191,71,146,129,214,224,152,240,17,82,211), 'Blobify';
 
-is ~$uuid, '39ed750e-a1bf-4792-81d6-e098f01152d3', 'Stringify';
+ok (~$uuid).fc eq '39ed750e-a1bf-4792-81d6-e098f01152d3'.fc, 'Stringify';
 
 done-testing;


### PR DESCRIPTION
Not sure if these are passing on Linux/Windows, but on macOS you get back UUIDs with all caps, do you need to care about case as its not distinct in UUID?